### PR TITLE
Merge rn-master into master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 .bundle
 .config
 .yardoc
-Gemfile.lock
 doc/
 lib/bundler/man
 pkg

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,35 @@
+PATH
+  remote: .
+  specs:
+    duo_security (0.0.2)
+      httparty (~> 0.21)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.8.4)
+      public_suffix (>= 2.0.2, < 6.0)
+    crack (0.4.5)
+      rexml
+    httparty (0.21.0)
+      mini_mime (>= 1.0.0)
+      multi_xml (>= 0.5.2)
+    mini_mime (1.1.2)
+    multi_xml (0.6.0)
+    public_suffix (5.0.1)
+    rexml (3.2.5)
+    vcr (2.2.5)
+    webmock (1.8.11)
+      addressable (>= 2.2.7)
+      crack (>= 0.1.7)
+
+PLATFORMS
+  aarch64-linux
+
+DEPENDENCIES
+  duo_security!
+  vcr (~> 2.2.4)
+  webmock (~> 1.8.9)
+
+BUNDLED WITH
+   2.4.6

--- a/duo_security.gemspec
+++ b/duo_security.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = DuoSecurity::VERSION
 
-  gem.add_dependency "httparty", "~> 0.10"
+  gem.add_dependency "httparty", "~> 0.21"
   
   gem.add_development_dependency "vcr", "~> 2.2.4"
   gem.add_development_dependency "webmock", "~> 1.8.9"

--- a/lib/duo_security/api.rb
+++ b/lib/duo_security/api.rb
@@ -34,7 +34,7 @@ module DuoSecurity
     def preauth(user)
       response = post("/preauth", {"user" => user})["response"]
 
-      raise UnknownUser, response.fetch("status") if response.fetch("result") == "enroll"
+      raise UnknownUser, response.fetch("status") if response.fetch("result") == "enroll" || response.fetch("result") == "deny"
 
       return response
     end

--- a/lib/duo_security/attempt.rb
+++ b/lib/duo_security/attempt.rb
@@ -7,8 +7,9 @@ module DuoSecurity
 
     def login!
       preauth = @api.preauth(@username)
-      factor  = preauth["factors"].fetch("default")
-      
+      return false unless preauth["factors"].key?('default')
+
+      factor = preauth["factors"]["default"]
       @api.auth(@username, "auto", {"auto" => factor})
     rescue API::UnknownUser => e
       false


### PR DESCRIPTION
In `storenet` we use [rn-master](https://github.com/retailnext/storenet/blob/master/Gemfile#L69-L71) branch, but we need to keep the default branch (`master`) up to date for Dependabot.